### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint Checks
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/qdrant/n8n-nodes-qdrant/security/code-scanning/3](https://github.com/qdrant/n8n-nodes-qdrant/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow or job definition in `.github/workflows/pr.yaml`. Since the workflow only checks out code, sets up Node, installs dependencies, lints, and builds, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. You can add the `permissions` block either at the root of the workflow (to apply to all jobs) or at the job level (to apply only to the `npm-release` job). The best practice is to add it at the root level unless you have jobs with differing permission requirements.

Edit `.github/workflows/pr.yaml` to insert the following block after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
